### PR TITLE
Namespace slashes to path

### DIFF
--- a/src/ClassGenerator/Template/AutoloaderTemplate.php
+++ b/src/ClassGenerator/Template/AutoloaderTemplate.php
@@ -49,7 +49,7 @@ class AutoloaderTemplate extends AbstractTemplate
         $this->_outputPath = rtrim($outputPath, "\\/");
         $this->_outputNamespace = $outputNamespace;
 
-        $this->_classPath = sprintf('%s/%s/PHPFHIRAutoloader.php', $this->_outputPath, $this->_outputNamespace);
+        $this->_classPath = sprintf('%s/%s/PHPFHIRAutoloader.php', $this->_outputPath, str_replace('\\', '/',$this->_outputNamespace));
         $this->_className = sprintf('%s\\PHPFHIRAutoloader', $this->_outputNamespace);
     }
 

--- a/src/ClassGenerator/Template/ParserMapTemplate.php
+++ b/src/ClassGenerator/Template/ParserMapTemplate.php
@@ -48,7 +48,7 @@ class ParserMapTemplate extends AbstractTemplate
         $this->_outputPath = rtrim($outputPath, "\\/");
         $this->_outputNamespace = $outputNamespace;
 
-        $this->_classPath = sprintf('%s/%s/PHPFHIRParserMap.php', $this->_outputPath, $this->_outputNamespace);
+        $this->_classPath = sprintf('%s/%s/PHPFHIRParserMap.php', $this->_outputPath, str_replace('\\', '/',$this->_outputNamespace));
         $this->_className = sprintf('%s\\PHPFHIRParserMap', $this->_outputNamespace);
     }
 

--- a/src/ClassGenerator/Template/ResponseParserTemplate.php
+++ b/src/ClassGenerator/Template/ResponseParserTemplate.php
@@ -46,7 +46,7 @@ class ResponseParserTemplate extends AbstractTemplate
         $this->_outputPath = rtrim($outputPath, "\\/");
         $this->_outputNamespace = $outputNamespace;
 
-        $this->_classPath = sprintf('%s/%s/PHPFHIRResponseParser.php', $this->_outputPath, $this->_outputNamespace);
+        $this->_classPath = sprintf('%s/%s/PHPFHIRResponseParser.php', $this->_outputPath, str_replace('\\', '/',$this->_outputNamespace));
         $this->_className = sprintf('%s\\PHPFHIRResponseParser', $this->_outputNamespace);
     }
 


### PR DESCRIPTION
A namespace can have multiple slashes in it, the path is derived form that namespace name but has backslashes and path needs forward slashes. 
(maybe not nicest notation but works)