### PR TITLE
Implemented functionality to override the generation of a property 

### DIFF
--- a/src/ClassGenerator/Generator/MethodGenerator.php
+++ b/src/ClassGenerator/Generator/MethodGenerator.php
@@ -32,7 +32,7 @@ use DCarbone\PHPFHIR\ClassGenerator\Utilities\NameUtils;
  */
 abstract class MethodGenerator
 {
-    private static $overrides = [];
+    private static $overrides = array();
 
     /**
      * @param array $overrides
@@ -307,7 +307,7 @@ abstract class MethodGenerator
                     continue;
 
                 // Check if there are overrides for this element
-                $propertyOverrides = [];
+                $propertyOverrides = array();
                 if (array_key_exists($name, self::$overrides)) {
                     $propertyOverrides = self::$overrides[$name];
                 }

--- a/src/ClassGenerator/Generator/MethodGenerator.php
+++ b/src/ClassGenerator/Generator/MethodGenerator.php
@@ -32,6 +32,16 @@ use DCarbone\PHPFHIR\ClassGenerator\Utilities\NameUtils;
  */
 abstract class MethodGenerator
 {
+    private static $overrides = [];
+
+    /**
+     * @param array $overrides
+     */
+    public static function setOverrides(array $overrides)
+    {
+        self::$overrides = $overrides;
+    }
+
     /**
      * @param ClassTemplate $classTemplate
      * @param \DCarbone\PHPFHIR\ClassGenerator\Template\Property\BasePropertyTemplate $propertyTemplate
@@ -296,6 +306,12 @@ abstract class MethodGenerator
                 if ('_fhirElementName' === $name)
                     continue;
 
+                // Check if there are overrides for this element
+                $propertyOverrides = [];
+                if (array_key_exists($name, self::$overrides)) {
+                    $propertyOverrides = self::$overrides[$name];
+                }
+
                 if ($property->isCollection())
                 {
                     $method->addLineToBody(sprintf(
@@ -321,16 +337,34 @@ abstract class MethodGenerator
                         'if (null !== $this->%s) {',
                         $name
                     ));
-                    $method->addLineToBody(sprintf(
-                        '    $%sElement = $sxe->addChild(\'%s\');',
-                        $name,
-                        $name
-                    ));
-                    $method->addLineToBody(sprintf(
-                        '    $%sElement->addAttribute(\'value\', (string)$this->%s);',
-                        $name,
-                        $name
-                    ));
+
+                    if (array_key_exists('attribute', $propertyOverrides) && $propertyOverrides['attribute'] === true) {
+                        $attributeName = 'value';
+                        if (array_key_exists('elementName', $propertyOverrides)) {
+                            $attributeName = $propertyOverrides['elementName'];
+                        }
+
+                        $method->addLineToBody(sprintf(
+                            '    $sxe->addAttribute(\'%s\', (string)$this->%s);',
+                            $attributeName,
+                            $name
+                        ));
+                    } else {
+                        $elementName = $name;
+                        if(array_key_exists('attribute', $propertyOverrides) && array_key_exists('elementName', $propertyOverrides) && $propertyOverrides['attribute'] === false){
+                            $elementName = $propertyOverrides['elementName'];
+                        }
+                        $method->addLineToBody(sprintf(
+                            '    $%sElement = $sxe->addChild(\'%s\');',
+                            $name,
+                            $elementName
+                        ));
+                        $method->addLineToBody(sprintf(
+                            '    $%sElement->addAttribute(\'value\', (string)$this->%s);',
+                            $name,
+                            $name
+                        ));
+                    }
                     $method->addLineToBody('}');
                 }
                 else


### PR DESCRIPTION
I needed a way to change the generation of the model properties.
Since a project I'm working on uses the fhir spec but made some minor changes to it.
Mainly they serialize the id as attribute.
This commit makes it possible with a configuration like the following:

```
<?php

require __DIR__.'/../vendor/autoload.php';

use DCarbone\PHPFHIR\ClassGenerator\Generator;
use DCarbone\PHPFHIR\ClassGenerator\Generator\MethodGenerator;

$fhir_overrides = ['id' => ['attribute' => true, 'elementName' => 'id']];

MethodGenerator::setOverrides($fhir_overrides);

$generator = new Generator(__DIR__.'/../resources/xsd/', __DIR__.'/generated/models/');
$generator->generate();
```

id is the element that we have defined overrides for
attribute true means we want to generate id as attribute, not as child element, false would mean it would be generated as a child element
elementName is the name that will be used for the child element name, or the attribute name.

