### PR TITLE
Fix to support STU3+ version of FHIR, Allow numbers in namespaces

### DIFF
--- a/src/ClassGenerator/Enum/BaseObjectTypeEnum.php
+++ b/src/ClassGenerator/Enum/BaseObjectTypeEnum.php
@@ -28,4 +28,5 @@ class BaseObjectTypeEnum extends Enum
     const BACKBONE_ELEMENT = 'BackboneElement';
     const RESOURCE = 'Resource';
     const DOMAIN_RESOURCE = 'DomainResource';
+    const QUANTITY = 'Quantity';
 }

--- a/src/ClassGenerator/Enum/ComplexClassTypesEnum.php
+++ b/src/ClassGenerator/Enum/ComplexClassTypesEnum.php
@@ -28,4 +28,5 @@ class ComplexClassTypesEnum extends Enum
     const RESOURCE = 'Resource';
     const ELEMENT = 'Element';
     const COMPONENT = 'Component';
+    const QUANTITY = 'Quantity';
 }

--- a/src/ClassGenerator/Utilities/NameUtils.php
+++ b/src/ClassGenerator/Utilities/NameUtils.php
@@ -23,9 +23,9 @@
 abstract class NameUtils
 {
     const VARIABLE_NAME_REGEX = '{^[a-zA-Z_][a-zA-Z0-9_]+$}S';
-    const FUNCNAME_REGEX = '{^[a-zA-Z0-9_]+$}S';
-    const CLASSNAME_REGEX = '{^[a-zA-Z0-9_]+$}S';
-    const NSNAME_REGEX = '{^[a-z0-9A-Z\\\_]+$}S';
+    const FUNCNAME_REGEX = '{^[a-zA-Z_][a-zA-Z0-9_]+$}S';
+    const CLASSNAME_REGEX = '{^[a-zA-Z_][a-zA-Z0-9_]+$}S';
+    const NSNAME_REGEX = '{^([a-zA-Z][a-z0-9A-Z_]*\\\?)+$}S';
 
     /** @var array */
     public static $classNameSearch = array(

--- a/src/ClassGenerator/Utilities/NameUtils.php
+++ b/src/ClassGenerator/Utilities/NameUtils.php
@@ -22,9 +22,9 @@
  */
 abstract class NameUtils
 {
-    const VARIABLE_NAME_REGEX = '{^[a-zA-Z_][a-zA-Z0-9_]+$}S';
-    const FUNCNAME_REGEX = '{^[a-zA-Z_][a-zA-Z0-9_]+$}S';
-    const CLASSNAME_REGEX = '{^[a-zA-Z_][a-zA-Z0-9_]+$}S';
+    const VARIABLE_NAME_REGEX = '{^[a-zA-Z_][a-zA-Z0-9_]*$}S';
+    const FUNCNAME_REGEX = '{^[a-zA-Z_][a-zA-Z0-9_]*$}S';
+    const CLASSNAME_REGEX = '{^[a-zA-Z_][a-zA-Z0-9_]*$}S';
     const NSNAME_REGEX = '{^([a-zA-Z][a-z0-9A-Z_]*\\\?)+$}S';
 
     /** @var array */

--- a/src/ClassGenerator/Utilities/NameUtils.php
+++ b/src/ClassGenerator/Utilities/NameUtils.php
@@ -25,7 +25,7 @@ abstract class NameUtils
     const VARIABLE_NAME_REGEX = '{^[a-zA-Z_][a-zA-Z0-9_]+$}S';
     const FUNCNAME_REGEX = '{^[a-zA-Z0-9_]+$}S';
     const CLASSNAME_REGEX = '{^[a-zA-Z0-9_]+$}S';
-    const NSNAME_REGEX = '{^[a-zA-Z\\\_]+$}S';
+    const NSNAME_REGEX = '{^[a-z0-9A-Z\\\_]+$}S';
 
     /** @var array */
     public static $classNameSearch = array(


### PR DESCRIPTION
Hi,

Thanks for the excellent php-fhir library. I tried to generate all versions of FHIR (DSTU1, DSTU2, STU3 and Build (nightly)). Versions above DSTU2 do not work because of missing 'Quantity' base enum. I added it and now it works. 

Also the namespace regex would not allow namespaces with numbers like 'HL7' and 'Dstu2'. I loosened up the regex a bit. Maybe even better to lookup the PHP spec to see if this leaves any invalid namespaces.

Regards, Pim