### PR TITLE
ignore parsing properties prefixed with an underscore

### DIFF
--- a/templates/response_parser_template.php
+++ b/templates/response_parser_template.php
@@ -171,7 +171,7 @@ class PHPFHIRResponseParser
 
                 // Ignore properties prefixed with an underscore
                 // Parsing the document fails with these properties
-                if (false !== strpos(\$k, '_')) {
+                if (0 === strpos(\$k, '_')) {
                     continue;
                 } elseif (!isset(\$properties[\$k])) {
                     \$this->_triggerPropertyNotFoundError(\$fhirElementName, \$k);

--- a/templates/response_parser_template.php
+++ b/templates/response_parser_template.php
@@ -170,8 +170,7 @@ class PHPFHIRResponseParser
                 }
 
                 // Ignore properties prefixed with an underscore
-                // The fhir spec makes no mention of these, but some ehrs
-                // Have an implementation of underscore prefixed properties
+                // Parsing the document fails with these properties
                 if (false !== strpos(\$k, '_')) {
                     continue;
                 } elseif (!isset(\$properties[\$k])) {

--- a/templates/response_parser_template.php
+++ b/templates/response_parser_template.php
@@ -112,7 +112,7 @@ class PHPFHIRResponseParser
             (\$error ? \$error->message : 'Unknown Error')
         ));
     }
-    
+
     /**
      * @param array \$jsonEntry
      * @param string \$fhirElementName
@@ -169,8 +169,12 @@ class PHPFHIRResponseParser
                         continue 2;
                 }
 
-                if (!isset(\$properties[\$k]))
-                {
+                // Ignore properties prefixed with an underscore
+                // The fhir spec make no mention of these, but some ehrs
+                // Have an implementation of underscore prefixed properties
+                if (false !== strpos(\$k, '_')) {
+                    continue;
+                } elseif (!isset(\$properties[\$k])) {
                     \$this->_triggerPropertyNotFoundError(\$fhirElementName, \$k);
                     continue;
                 }
@@ -204,7 +208,7 @@ class PHPFHIRResponseParser
 
         return \$object;
     }
-    
+
     /**
      * @param \SimpleXMLElement \$element
      * @param string \$fhirElementName

--- a/templates/response_parser_template.php
+++ b/templates/response_parser_template.php
@@ -170,7 +170,7 @@ class PHPFHIRResponseParser
                 }
 
                 // Ignore properties prefixed with an underscore
-                // The fhir spec make no mention of these, but some ehrs
+                // The fhir spec makes no mention of these, but some ehrs
                 // Have an implementation of underscore prefixed properties
                 if (false !== strpos(\$k, '_')) {
                     continue;


### PR DESCRIPTION
It appears that certain EHRs may implement json attributes prefixed with an underscore. These attributes do not appear to be supported by any version of the fhir specification.

**Edit-** After looking through some of the issues mentioned here it appears as though I am incorrect about underscore prefixes, and that a refactor solution is in place to address the issue.

Is there an ETA on the refactor?