### PR TITLE
fix for BUILD version of fhir which contains changes/updates

### DIFF
--- a/src/ClassGenerator/Enum/BaseObjectTypeEnum.php
+++ b/src/ClassGenerator/Enum/BaseObjectTypeEnum.php
@@ -24,9 +24,14 @@ use MyCLabs\Enum\Enum;
  */
 class BaseObjectTypeEnum extends Enum
 {
-    const ELEMENT = 'Element';
     const BACKBONE_ELEMENT = 'BackboneElement';
-    const RESOURCE = 'Resource';
+    const BACKBONE_TYPE = 'BackboneType';
+    const BASE = 'Base';
+    const CANONICAL_RESOURCE = 'CanonicalResource';
+    const DATA_TYPE = 'DataType';
     const DOMAIN_RESOURCE = 'DomainResource';
+    const ELEMENT = 'Element';
+    const METADATA_RESOURCE = 'MetadataResource';
     const QUANTITY = 'Quantity';
+    const RESOURCE = 'Resource';
 }

--- a/src/ClassGenerator/Enum/ComplexClassTypesEnum.php
+++ b/src/ClassGenerator/Enum/ComplexClassTypesEnum.php
@@ -24,9 +24,14 @@ use MyCLabs\Enum\Enum;
  */
 class ComplexClassTypesEnum extends Enum
 {
-    const DOMAIN_RESOURCE = 'DomainResource';
-    const RESOURCE = 'Resource';
-    const ELEMENT = 'Element';
+    const BACKBONE_TYPE = 'BackboneType';
+    const BASE = 'Base';
+    const CANONICAL_RESOURCE = 'CanonicalResource';
     const COMPONENT = 'Component';
+    const DATA_TYPE = 'DataType';
+    const DOMAIN_RESOURCE = 'DomainResource';
+    const ELEMENT = 'Element';
+    const METADATA_RESOURCE = 'MetadataResource';
     const QUANTITY = 'Quantity';
+    const RESOURCE = 'Resource';
 }


### PR DESCRIPTION
The current BUILD version(4.2.0) from HL7 made some changes. 

The updates here appear to remain backward compatible in generating the models from my own test cases. I also alpha ordered the constants here for clarity.