### PR TITLE
Fix a typo in readme which breaks example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $config = new \DCarbone\PHPFHIR\Config([
     'schemaPath'  => __DIR__ . '/../input',
 
     // The path to place generated type class files
-    'classesPath' => '__DIR__ . '/../output',
+    'classesPath' => __DIR__ . '/../output',
 
     // If true, will use a noop null logger
     'silent'      => false,


### PR DESCRIPTION
Just fixing a typo in the readme, as currently the example doesn't work from the get-go.