### PR TITLE
Improved default XML serialization location

### DIFF
--- a/template/types/properties/methods/default.php
+++ b/template/types/properties/methods/default.php
@@ -66,16 +66,22 @@ foreach ($properties as $property) :
      * @param <?php echo $config->getFullyQualifiedName(true, PHPFHIR_ENUM_XML_LOCATION_ENUM); ?> $xmlLocation
      * @return static
      */
-    public function <?php echo $property->getSetterName(); ?>(<?php echo TypeHintUtils::propertySetterTypeHint($config, $property, true); ?> $<?php echo $property; ?> = null, <?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?> $xmlLocation = <?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?>::ATTRIBUTE): self
+    public function <?php echo $property->getSetterName(); ?>(<?php echo TypeHintUtils::propertySetterTypeHint($config, $property, true); ?> $<?php echo $property; ?> = null, <?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?> $xmlLocation = <?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?>::<?php if ($propertyType->isValueContainer()): ?>ELEMENT<?php else : ?>ATTRIBUTE<?php endif; ?>): self
     {
         if (null !== $<?php echo $propertyName; ?> && !($<?php echo $propertyName; ?> instanceof <?php echo $propertyTypeClassName; ?>)) {
             $<?php echo $propertyName; ?> = new <?php echo $propertyTypeClassName; ?>($<?php echo $propertyName; ?>);
         }
         $this->_trackValue<?php if ($isCollection) : ?>Added(<?php else : ?>Set($this-><?php echo $propertyName; ?>, $<?php echo $propertyName; endif; ?>);
-        if (!isset($this->_primitiveXmlLocations[self::<?php echo $property->getFieldConstantName(); ?>])) {
-            $this->_primitiveXmlLocations[self::<?php echo $property->getFieldConstantName(); ?>] = [];
+        if (!isset($this->_xmlLocations[self::<?php echo $property->getFieldConstantName(); ?>])) {
+            $this->_xmlLocations[self::<?php echo $property->getFieldConstantName(); ?>] = [];
         }
-        $this->_primitiveXmlLocations[self::<?php echo $property->getFieldConstantName(); ?>]<?php if ($isCollection) : ?>[]<?php else : ?>[0]<?php endif; ?> = $xmlLocation;
+        <?php if ($isCollection) : ?>if ([] === $this->_xmlLocations[self::<?php echo $property->getFieldConstantName(); ?>]) {
+            $this->_xmlLocations[self::<?php echo $property->getFieldConstantName(); ?>][0] = $xmlLocation;
+        } else {
+            $this->_xmlLocations[self::<?php echo $property->getFieldConstantName(); ?>][] = <?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?>::ELEMENT;
+        }<?php else : ?>
+$this->_xmlLocations[self::<?php echo $property->getFieldConstantName(); ?>][0] = $xmlLocation;<?php endif; ?>
+
         $this-><?php echo $propertyName; ?><?php echo $isCollection ? '[]' : ''; ?> = $<?php echo $propertyName; ?>;
         return $this;
     }
@@ -91,9 +97,9 @@ foreach ($properties as $property) :
      * @param <?php echo $config->getFullyQualifiedName(true, PHPFHIR_ENUM_XML_LOCATION_ENUM); ?> $xmlLocation
      * @return static
      */
-    public function set<?php echo ucfirst($propertyName); ?>(array $<?php echo $propertyName; ?> = [], <?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?> $xmlLocation = <?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?>::ATTRIBUTE): self
+    public function set<?php echo ucfirst($propertyName); ?>(array $<?php echo $propertyName; ?> = [], <?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?> $xmlLocation = <?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?>::<?php if ($propertyType->isValueContainer()): ?>ELEMENT<?php else : ?>ATTRIBUTE<?php endif; ?>): self
     {
-        unset($this->_primitiveXmlLocations[self::<?php echo $property->getFieldConstantName(); ?>]);
+        unset($this->_xmlLocations[self::<?php echo $property->getFieldConstantName(); ?>]);
         if ([] !== $this-><?php echo $propertyName; ?>) {
             $this->_trackValuesRemoved(count($this-><?php echo $propertyName; ?>));
             $this-><?php echo $propertyName; ?> = [];

--- a/template/types/serialization/xml/primitive_xml_location_map.php
+++ b/template/types/serialization/xml/primitive_xml_location_map.php
@@ -21,5 +21,5 @@
 
 ob_start(); ?>
     /** @var array */
-    private array $_primitiveXmlLocations = [];
+    private array $_xmlLocations = [];
 <?php return ob_get_clean();

--- a/template/types/serialization/xml/serialize/body.php
+++ b/template/types/serialization/xml/serialize/body.php
@@ -39,7 +39,7 @@ foreach ($type->getLocalProperties()->localPropertiesIterator() as $property) :
         continue;
     }
     if ($pt->hasPrimitiveParent() || $pt->getKind()->isOneOf(TypeKind::PRIMITIVE, TypeKind::LIST)) : ?>
-        $locs = $this->_primitiveXmlLocations[self::<?php echo $property->getFieldConstantName(); ?>] ?? [];
+        $locs = $this->_xmlLocations[self::<?php echo $property->getFieldConstantName(); ?>] ?? [];
 <?php   if ($property->isCollection()) : ?>
         if ([] === $locs && [] !== ($vs = $this-><?php echo $property->getGetterName(); ?>())) {
             $xw->writeAttribute(self::<?php echo $property->getFieldConstantName(); ?>, $vs[0]->getFormattedValue());
@@ -52,7 +52,7 @@ foreach ($type->getLocalProperties()->localPropertiesIterator() as $property) :
         }
 <?php   endif;
     elseif ($pt->getKind() === TypeKind::PRIMITIVE_CONTAINER) : ?>
-        $locs = $this->_primitiveXmlLocations[self::<?php echo $property->getFieldConstantName(); ?>] ?? [];
+        $locs = $this->_xmlLocations[self::<?php echo $property->getFieldConstantName(); ?>] ?? [];
 <?php   if ($property->isCollection()) : ?>
         if ([] === $locs && [] !== ($vs = $this-><?php echo $property->getGetterName(); ?>())) {
             $xw->writeAttribute(self::<?php echo $property->getFieldConstantName(); ?>, $vs[0]->getValue()?->getFormattedValue());
@@ -99,7 +99,7 @@ foreach ($localProperties as $property) :
         }
 <?php       endif;
         elseif ($pt->hasPrimitiveParent() || $ptk->isOneOf(TypeKind::LIST, TypeKind::PRIMITIVE)) : ?>
-        $locs = $this->_primitiveXmlLocations[self::<?php echo $property->getFieldConstantName(); ?>] ?? [];
+        $locs = $this->_xmlLocations[self::<?php echo $property->getFieldConstantName(); ?>] ?? [];
 <?php        if ($property->isCollection()) : ?>
         if (([] === $locs || in_array(<?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?>::ELEMENT, $locs, true)) && [] !== ($vs = $this-><?php echo $property->getGetterName(); ?>())) {
             foreach($vs as $i => $v) {
@@ -118,7 +118,7 @@ foreach ($localProperties as $property) :
         }
 <?php       endif;
         elseif ($ptk === TypeKind::PRIMITIVE_CONTAINER) : ?>
-        $locs = $this->_primitiveXmlLocations[self::<?php echo $property->getFieldConstantName(); ?>] ?? [];
+        $locs = $this->_xmlLocations[self::<?php echo $property->getFieldConstantName(); ?>] ?? [];
 <?php        if ($property->isCollection()) : ?>
         if (([] === $locs || in_array(<?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?>::ELEMENT, $locs, true)) && [] !== ($vs = $this-><?php echo $property->getGetterName(); ?>())) {
             foreach($vs as $i => $v) {
@@ -156,7 +156,7 @@ else:
     //
     // Uncomment and implement properly if the need arises in the future.
     /*?>
-        if (($this->_primitiveXmlLocations[self::FIELD_VALUE] ?? <?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?>::ATTRIBUTE) === <?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?>::ELEMENT) {
+        if (($this->_xmlLocations[self::FIELD_VALUE] ?? <?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?>::ATTRIBUTE) === <?php echo PHPFHIR_ENUM_XML_LOCATION_ENUM; ?>::ELEMENT) {
             $xw->writeSimpleElement(self::FIELD_VALUE, $this->getFormattedValue());
         }
 <?php */ endif;

--- a/template/types/tests/unit/class.php
+++ b/template/types/tests/unit/class.php
@@ -43,7 +43,7 @@ echo require_with(
     ]
 );
 
-if ($typeKind === TypeKind::PRIMITIVE) :
+if ($typeKind === TypeKind::PRIMITIVE) {
     echo require_with(
         PHPFHIR_TEMPLATE_TYPE_TESTS_DIR . DIRECTORY_SEPARATOR . $testType->value . DIRECTORY_SEPARATOR . 'body_primitive.php',
         [
@@ -51,7 +51,7 @@ if ($typeKind === TypeKind::PRIMITIVE) :
             'type' => $type,
         ]
     );
-endif;
+}
 
 echo "}\n";
 return ob_get_clean();


### PR DESCRIPTION
This PR does the following

* When adding new value containing and primitive types to collection fields, only the first will be allowed to be serialized to an XML attribute
* Updating the default `$xmlLocation` value of value container types to element