### PR TITLE
Try to assert json data is for intended resource

### DIFF
--- a/src/Render/Templates.php
+++ b/src/Render/Templates.php
@@ -22,7 +22,6 @@ use DCarbone\PHPFHIR\Config;
 use DCarbone\PHPFHIR\CoreFile;
 use DCarbone\PHPFHIR\Version;
 use DCarbone\PHPFHIR\Version\Definition\Type;
-use DCarbone\PHPFHIR\Version\Definition\Types;
 
 /**
  * Class TemplateBuilder

--- a/template/core/encoding/trait_xml_serialization_options.php
+++ b/template/core/encoding/trait_xml_serialization_options.php
@@ -50,8 +50,7 @@ trait <?php echo $coreFile; ?>
     }
 
     /**
-     * Set the location a particular field's value must be placed when serializing this type to XML.  Each type has
-     * a limited number of fields that may be serialized to XML
+     * Set the location a particular field's value must be placed when serializing this type to XML.
      *
      * @param string $field Name of field on this type.
      * @throws \DomainException

--- a/template/tests/versions/types/class.php
+++ b/template/tests/versions/types/class.php
@@ -171,7 +171,7 @@ if (!$type->isAbstract()
     }
 <?php if ($primitiveType->isOneOf(PrimitiveTypeEnum::DATE, PrimitiveTypeEnum::DATETIME, PrimitiveTypeEnum::INSTANT, PrimitiveTypeEnum::TIME)): ?>
 
-    public function testCanSetValueAsDateTime()
+    public function testCanSetValueWithDateTime()
     {
         $date = \DateTime::createFromFormat("Y-m-d\TH:i:sP", '2020-02-02T20:20:20+00:00');
         $type = new <?php echo $type->getClassName(); ?>(value: $date);
@@ -185,8 +185,7 @@ if (!$type->isAbstract()
         $this->assertEquals($date->format('Y-m-d\TH:i:s\.uP'), $type->_getValueAsString());
 <?php endif; ?>
     }
-<?php
-endif;
+<?php endif;
 elseif (!$version->getSourceMetadata()->isDSTU1()) :
     if ($type->isResourceType() || $type->hasResourceTypeParent()) :
         if ($type->hasResourceTypeParent()

--- a/template/versions/types/serialization/json/unserialize/header.php
+++ b/template/versions/types/serialization/json/unserialize/header.php
@@ -58,6 +58,13 @@ ob_start(); ?>
             throw new \RuntimeException(sprintf('%s::xmlUnserialize: Cannot unserialize directly into root type', static::class));
         }<?php else : ?>
         if (null === $type) {
+            if (isset($decoded-><?php echo PHPFHIR_JSON_FIELD_RESOURCE_TYPE; ?>) && $decoded-><?php echo PHPFHIR_JSON_FIELD_RESOURCE_TYPE; ?> !== static::FHIR_TYPE_NAME) {
+                throw new \DomainException(sprintf(
+                    '%s::jsonUnserialize - Cannot unmarshal data for resource type "%s" into this type.',
+                    ltrim(substr(__CLASS__, (int)strrpos(__CLASS__, '\\')), '\\'),
+                    $decoded-><?php echo PHPFHIR_JSON_FIELD_RESOURCE_TYPE; ?>,
+                ));
+            }
             $type = new static();
         }<?php endif; ?> else if (!($type instanceof <?php echo $type->getClassName(); ?>)) {
             throw new \RuntimeException(sprintf(


### PR DESCRIPTION
When unmarshalling into a type from JSON without first instantiating a type instance, check to see if the `resourceType` field is set.  If it is set, assert that its value is equivalent to the type of resource being unmarshalled into.

If an instance of the model has already been created or the incoming decoded JSON does _not_ have the `resourceType` field, this check is skipped.

TODO: Some tests around this.