### PR TITLE
fix: correct regex delimiter in OptMask validation patterns

### DIFF
--- a/src/Version/VersionDefaultConfig.php
+++ b/src/Version/VersionDefaultConfig.php
@@ -89,7 +89,7 @@ class VersionDefaultConfig
             }
             $this->_unserializeConfig[$k] = match ($k) {
                 'libxmlOpts' => intval($config[$k]),
-                'libxmlOptMask' => is_string($config[$k]) && preg_match('{^[A-Z0-9_\s|]+}$}', $config[$k])
+                'libxmlOptMask' => is_string($config[$k]) && preg_match('{^[A-Z0-9_\s|]+$}', $config[$k])
                     ? $config[$k]
                     : throw new \InvalidArgumentException(sprintf(
                         'Value provided to "libxmlOptMask" is either not a string or is an invalid options mask: %s',
@@ -97,7 +97,7 @@ class VersionDefaultConfig
                     )),
                 'jsonDecodeMaxDepth' => intval($config[$k]),
                 'jsonDecodeOpts' => intval($config[$k]),
-                'jsonDecodeOptMask '=> is_string($config[$k]) && preg_match('{^[A-Z0-9_\s|]+}$}', $config[$k])
+                'jsonDecodeOptMask '=> is_string($config[$k]) && preg_match('{^[A-Z0-9_\s|]+$}', $config[$k])
                     ? $config[$k]
                     : throw new \InvalidArgumentException(sprintf(
                         'Value provided to "jsonDecodeOptMask" is either not a string or is an invalid options mask: %s',
@@ -142,7 +142,7 @@ class VersionDefaultConfig
                 'overrideSourceXMLNS' => (bool)$config[$k],
                 'rootXMLNS' => null === $config[$k] ? null : (string)$config[$k],
                 'xhtmlLibxmlOpts' => intval($config[$k]),
-                'xhtmlLibxmlOptMask' => is_string($config[$k]) && preg_match('{^[A-Z0-9_\s|]+}$}', $config[$k])
+                'xhtmlLibxmlOptMask' => is_string($config[$k]) && preg_match('{^[A-Z0-9_\s|]+$}', $config[$k])
                     ? $config[$k]
                     : throw new \InvalidArgumentException(sprintf(
                         'Value provided to "xhtmlLibxmlOptMask" is either not a string or is an invalid options mask: %s',


### PR DESCRIPTION
## Problem

All three `OptMask` validation patterns in `VersionDefaultConfig.php` contain the same broken regex:

```php
preg_match('{^[A-Z0-9_\s|]+}$}', $config[$k])
```

The `}` before `$` acts as the closing PCRE delimiter, leaving `$` as an unrecognized modifier. PHP emits:

```
Warning: preg_match(): Unknown modifier '$'
```

`preg_match()` returns `false`, which evaluates as falsy in the `&&` chain, so the throw branch always executes. Every valid mask string (e.g. `JSON_THROW_ON_ERROR`, `LIBXML_NONET|LIBXML_COMPACT`) is rejected.

**Affected lines:**
- Line 92: `libxmlOptMask`
- Line 100: `jsonDecodeOptMask`
- Line 145: `xhtmlLibxmlOptMask`

## Fix

Move `$` inside the pattern, before the closing delimiter:

```php
// Before (broken)
preg_match('{^[A-Z0-9_\s|]+}$}', $config[$k])

// After
preg_match('{^[A-Z0-9_\s|]+$}', $config[$k])
```

## Verification

```
$ php -r "var_dump(preg_match('{^[A-Z0-9_\s|]+}\$}', 'JSON_THROW_ON_ERROR'));"
Warning: preg_match(): Unknown modifier '$'
bool(false)

$ php -r "var_dump(preg_match('{^[A-Z0-9_\s|]+\$}', 'JSON_THROW_ON_ERROR'));"
int(1)
```

## Test plan

- [ ] Pass a valid mask string to `libxmlOptMask` — should be accepted
- [ ] Pass a valid mask string to `jsonDecodeOptMask` — should be accepted (requires #188 for key fix)
- [ ] Pass a valid mask string to `xhtmlLibxmlOptMask` — should be accepted
- [ ] Pass an invalid mask string (e.g. `foo bar!`) — should still throw `InvalidArgumentException`

Note: this fix is independent of #188 (key typo fix) but both are needed for `jsonDecodeOptMask` to work end-to-end.