### PR TITLE
Normalize whitespace in rendered template output

### DIFF
--- a/src/Render/Templates.php
+++ b/src/Render/Templates.php
@@ -38,7 +38,7 @@ abstract class Templates
     public static function renderCoreFile(Config $config, CoreFile $coreFile, array $kwargs): string
     {
         extract($kwargs);
-        return require $coreFile->getTemplateFile();
+        return self::normalize(require $coreFile->getTemplateFile());
     }
 
     /**
@@ -48,7 +48,7 @@ abstract class Templates
      */
     public static function renderVersionXHTMLTypeClass(Version $version, Type $type): string
     {
-        return require sprintf('%s/class_xhtml.php', PHPFHIR_TEMPLATE_VERSION_TYPES_DIR);
+        return self::normalize(require sprintf('%s/class_xhtml.php', PHPFHIR_TEMPLATE_VERSION_TYPES_DIR));
     }
 
     /**
@@ -59,11 +59,11 @@ abstract class Templates
     public static function renderVersionTypeClass(Version $version, Type $type): string
     {
         if ($type->getKind()->isResourceContainer($version)) {
-            return require sprintf('%s/class_resource_container.php', PHPFHIR_TEMPLATE_VERSION_TYPES_DIR);
+            return self::normalize(require sprintf('%s/class_resource_container.php', PHPFHIR_TEMPLATE_VERSION_TYPES_DIR));
         } else if ($type->isPrimitiveType() && !$type->hasPrimitiveTypeParent()) {
-            return require sprintf('%s/class_primitive.php', PHPFHIR_TEMPLATE_VERSION_TYPES_DIR);
+            return self::normalize(require sprintf('%s/class_primitive.php', PHPFHIR_TEMPLATE_VERSION_TYPES_DIR));
         }
-        return require sprintf('%s/class_default.php', PHPFHIR_TEMPLATE_VERSION_TYPES_DIR);
+        return self::normalize(require sprintf('%s/class_default.php', PHPFHIR_TEMPLATE_VERSION_TYPES_DIR));
     }
 
     /**
@@ -73,6 +73,24 @@ abstract class Templates
      */
     public static function renderVersionTypeClassTest(Version $version, Type $type): string
     {
-        return require sprintf('%s/class.php', PHPFHIR_TEMPLATE_TESTS_VERSIONS_TYPES_DIR);
+        return self::normalize(require sprintf('%s/class.php', PHPFHIR_TEMPLATE_TESTS_VERSIONS_TYPES_DIR));
+    }
+
+    /**
+     * Normalize whitespace in rendered template output.
+     *
+     * Templates are PHP files rendered via output buffering, so indented inline control
+     * structures (e.g. "    <?php endif; ?>") emit their leading indentation as whitespace-only
+     * or trailing-whitespace lines. Normalizing here, at the single render chokepoint, keeps
+     * every generated file free of trailing whitespace and ending in exactly one newline,
+     * without editing each template.
+     *
+     * @param string $rendered
+     * @return string
+     */
+    private static function normalize(string $rendered): string
+    {
+        $rendered = preg_replace('/[ \t]+$/m', '', $rendered);
+        return rtrim($rendered, "\r\n") . "\n";
     }
 }


### PR DESCRIPTION
## What

Generated code currently carries per-line trailing whitespace, and rendered files don't consistently end in a newline. This normalizes both at the single render chokepoint in `Templates`, so every generated file (core, version core, type classes, and tests) comes out free of trailing whitespace and ending in exactly one newline.

## Why

Templates are PHP files rendered via output buffering. Indented inline control structures — e.g. `    <?php endif; ?>` — emit their leading indentation as whitespace-only or trailing-whitespace lines in the output. Because every template returns through `Templates::render*`, a single `normalize()` step there cleans every generated file at once, with no need to touch the individual templates.

## How it was verified

- `phpunit -c phpunit/Builder.xml` — all 70 tests pass.
- Generated DSTU1 before vs. after: **6,639** trailing-whitespace lines across all 446 files → **0**, and **0** files not ending in exactly one newline. Diffing the two trees (after stripping trailing whitespace and ignoring embedded generation timestamps) shows the change is whitespace-only — no functional difference in the generated code.

## Is there appetite for more of this?

This is deliberately a small, self-contained first step. While digging in, I noticed a few other places where the generator could emit higher-quality code straight out of the box, and I'd be happy to send follow-up PRs if you're open to it:

- **Unused `use` imports** — some imports (`Constants`, `FHIRVersion`, container interfaces) are added speculatively per type-category even when a given type's body never references them, so they show up as unused.
- **Modern PHP idioms** — `__CLASS__` and `get_class($x)` in the templates could become `self::class` / `$x::class`.
- **A CI quality gate** — optionally, a phpcs (and/or rector) check that runs against generated output in the existing version matrix, so output quality is enforced rather than something each downstream consumer re-cleans on their own.

Totally understand if some or all of that is out of scope or not the direction you want — happy to take your lead. Mainly wanted to ask before investing further. Thanks for maintaining php-fhir!