### PR TITLE
Use modern class-name idioms (self::class / $x::class) in templates

### DIFF
--- a/template/core/class_autoloader.php
+++ b/template/core/class_autoloader.php
@@ -68,7 +68,7 @@ abstract class <?php echo $coreFile; ?>
     public static function register(): bool
     {
         if (!self::$_registered) {
-            self::$_registered = spl_autoload_register(__CLASS__ . '::loadClass');
+            self::$_registered = spl_autoload_register(self::class . '::loadClass');
         }
         return self::$_registered;
     }
@@ -76,7 +76,7 @@ abstract class <?php echo $coreFile; ?>
     public static function unregister(): bool
     {
         if (self::$_registered) {
-            if (spl_autoload_unregister(__CLASS__ . '::loadClass')) {
+            if (spl_autoload_unregister(self::class . '::loadClass')) {
                 self::$_registered = false;
                 return true;
             }

--- a/template/core/encoding/trait_xml_serialization_options.php
+++ b/template/core/encoding/trait_xml_serialization_options.php
@@ -61,7 +61,7 @@ trait <?php echo $coreFile; ?>
             throw new \DomainException(sprintf(
                 'Field "%s" on Type "%s" does not contain a value that is serializable as an attribute',
                 $field,
-                ltrim(substr(__CLASS__, (int)strrpos(__CLASS__, '\\')), '\\'),
+                ltrim(substr(self::class, (int)strrpos(self::class, '\\')), '\\'),
             ));
         }
         $this->_valueXMLLocations[$field] = $valueXMLLocation;
@@ -81,7 +81,7 @@ trait <?php echo $coreFile; ?>
             throw new \DomainException(sprintf(
                 'Field "%s" on Type "%s" does not contain a value that is serializable as an attribute',
                 $field,
-                ltrim(substr(__CLASS__, (int)strrpos(__CLASS__, '\\')), '\\'),
+                ltrim(substr(self::class, (int)strrpos(self::class, '\\')), '\\'),
             ));
         }
         return $this->_valueXMLLocations[$field];

--- a/template/tests/core/class_test_autoloader.php
+++ b/template/tests/core/class_test_autoloader.php
@@ -47,7 +47,7 @@ abstract class <?php echo $coreFile; ?>
     public static function register(): bool
     {
         if (!self::$_registered) {
-            self::$_registered = spl_autoload_register(__CLASS__ . '::loadClass');
+            self::$_registered = spl_autoload_register(self::class . '::loadClass');
         }
         return self::$_registered;
     }
@@ -55,7 +55,7 @@ abstract class <?php echo $coreFile; ?>
     public static function unregister(): bool
     {
         if (self::$_registered) {
-            if (spl_autoload_unregister(__CLASS__ . '::loadClass')) {
+            if (spl_autoload_unregister(self::class . '::loadClass')) {
                 self::$_registered = false;
                 return true;
             }

--- a/template/versions/core/class_autoloader.php
+++ b/template/versions/core/class_autoloader.php
@@ -63,7 +63,7 @@ abstract class <?php echo PHPFHIR_CLASSNAME_AUTOLOADER; ?>
     public static function register(): bool
     {
         if (!self::$_registered) {
-            self::$_registered = spl_autoload_register(__CLASS__ . '::loadClass', true);
+            self::$_registered = spl_autoload_register(self::class . '::loadClass', true);
         }
         return self::$_registered;
     }
@@ -74,7 +74,7 @@ abstract class <?php echo PHPFHIR_CLASSNAME_AUTOLOADER; ?>
     public static function unregister(): bool
     {
         if (self::$_registered) {
-            if (spl_autoload_unregister(__CLASS__ . '::loadClass')) {
+            if (spl_autoload_unregister(self::class . '::loadClass')) {
                 self::$_registered = false;
                 return true;
             }

--- a/template/versions/core/class_version.php
+++ b/template/versions/core/class_version.php
@@ -88,7 +88,7 @@ class <?php echo $coreFile; ?> implements <?php echo $versionInterface; ?>
             throw new \InvalidArgumentException(sprintf(
                 '$config must be an instance of \\%s, %s given',
                 <?php echo $versionConfigClass; ?>::class,
-                get_class($config)
+                $config::class
             ));
         }
         $this->_config = $config;

--- a/template/versions/types/serialization/json/unserialize/header.php
+++ b/template/versions/types/serialization/json/unserialize/header.php
@@ -61,7 +61,7 @@ ob_start(); ?>
             if (isset($decoded-><?php echo PHPFHIR_JSON_FIELD_RESOURCE_TYPE; ?>) && $decoded-><?php echo PHPFHIR_JSON_FIELD_RESOURCE_TYPE; ?> !== static::FHIR_TYPE_NAME) {
                 throw new \DomainException(sprintf(
                     '%s::jsonUnserialize - Cannot unmarshal data for resource type "%s" into this type.',
-                    ltrim(substr(__CLASS__, (int)strrpos(__CLASS__, '\\')), '\\'),
+                    ltrim(substr(self::class, (int)strrpos(self::class, '\\')), '\\'),
                     $decoded-><?php echo PHPFHIR_JSON_FIELD_RESOURCE_TYPE; ?>,
                 ));
             }
@@ -69,9 +69,9 @@ ob_start(); ?>
         }<?php endif; ?> else if (!($type instanceof <?php echo $type->getClassName(); ?>)) {
             throw new \RuntimeException(sprintf(
                 '%s::jsonUnserialize - $type must be instance of \\%s or null, %s seen.',
-                ltrim(substr(__CLASS__, (int)strrpos(__CLASS__, '\\')), '\\'),
+                ltrim(substr(self::class, (int)strrpos(self::class, '\\')), '\\'),
                 static::class,
-                get_class($type)
+                $type::class
             ));
         }
 <?php if ($isResource) : ?>

--- a/template/versions/types/serialization/xml/unserialize/header.php
+++ b/template/versions/types/serialization/xml/unserialize/header.php
@@ -61,9 +61,9 @@ ob_start(); ?>
         }<?php endif; ?> else if (!($type instanceof <?php echo $type->getClassName(); ?>)) {
             throw new \RuntimeException(sprintf(
                 '%s::xmlUnserialize - $type must be instance of \\%s or null, %s seen.',
-                ltrim(substr(__CLASS__, (int)strrpos(__CLASS__, '\\')), '\\'),
+                ltrim(substr(self::class, (int)strrpos(self::class, '\\')), '\\'),
                 static::class,
-                get_class($type)
+                $type::class
             ));
         }
 <?php if ($isResource) : ?>


### PR DESCRIPTION
## Summary

Replaces `__CLASS__` with `self::class` and `get_class($x)` with `$x::class` in the generator templates so the emitted code uses the conventional modern form.

- `self::class` resolves identically to `__CLASS__` (including inside traits), and reads more cleanly.
- `$x::class` is available since PHP 8.0 — well under the `^8.1` minimum for generated output.

7 templates touched, 14 lines changed.

Closes #197

## Test plan

- [ ] `php -l` passes on all changed templates (verified locally)
- [ ] CI generate-and-test cycle passes across the PHP 8.1–8.5 matrix